### PR TITLE
Add call to action for suggestion readers

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -29,3 +29,6 @@ Please tick all that apply:
 * [ ] I or my company would be willing to help implement and/or test this
 
 
+## For Readers
+
+If you would like to see this issue implemented, please click the :+1: emoji on this issue. These counts are used to generally order the suggestions by engagement.


### PR DESCRIPTION
There's some discussion on Slack about how to instruct readers about interaction with the suggestion issues. The main README says to :+1: issues that you want to see implemented, but when issues are directly linked that guidance is never seen. This attempts to call out precisely what's expected of a reader.